### PR TITLE
Adding proguard rules for ikev2 VPN Service of strongswan lib

### DIFF
--- a/ConsumerVPN/app/proguard-rules.pro
+++ b/ConsumerVPN/app/proguard-rules.pro
@@ -61,7 +61,7 @@
 -dontwarn com.bluelinelabs.logansquare.processor.**
 
 # Strongswan
--keep class org.strongswan.android.logic.** { *; }
+-keep class org.strongswan.android.logic.Scheduler { *; }
 
 # AutoValue
 -dontwarn javax.lang.**

--- a/ConsumerVPN/app/proguard-rules.pro
+++ b/ConsumerVPN/app/proguard-rules.pro
@@ -60,6 +60,9 @@
 -keep class **$$JsonObjectMapper { *; }
 -dontwarn com.bluelinelabs.logansquare.processor.**
 
+# Strongswan
+-keep class org.strongswan.android.logic.** { *; }
+
 # AutoValue
 -dontwarn javax.lang.**
 -dontwarn javax.tools.**


### PR DESCRIPTION
Issue: 
When publishing a release version of ConsumerVPN and trying to connect while having selected ikev2 as protocol, the app crashes because the class "CharonVpnService" can not be found. 

Tested Devices & Affected Devices:
Several Samsung and Pixel devices with Android 10-13. (Issue seems unrelated to device brand and android version)

Fix:
Added Proguard rule for CharonVpnService class. The class is located in org.strongswan.android.logic and the proguard rule can possibly be implemented even more strict. 